### PR TITLE
Define the scenario_bank instance variable before calling it

### DIFF
--- a/lib/cypress/middleware.rb
+++ b/lib/cypress/middleware.rb
@@ -55,6 +55,7 @@ module Cypress
       def handle_scenario(req)
         handle_setup(req)
 
+        @scenario_bank = ScenarioBank.new
         @scenario_bank.load
         if block = @scenario_bank[json_from_body(req)['scenario']]
           new_context.execute block


### PR DESCRIPTION
As pointed out in #3, the `@scenario_bank` instance variable is always undefined when the `load` method for scenarios is called. I actually didn't dig much into the code and for that I apologize in advance because I may have missed something relevant, but this little change made everything working for me.